### PR TITLE
transformers 4.0.0 need specify the return_dict argument to False

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.17.4
 tensorboard>=2.0.0
 torch>=1.3.1
 tqdm>=4.41.0
-transformers>=2.3.0
+transformers==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.17.4
 tensorboard>=2.0.0
 torch>=1.3.1
 tqdm>=4.41.0
-transformers==3.5.1
+transformers>=2.3.0

--- a/sa_model.py
+++ b/sa_model.py
@@ -66,7 +66,8 @@ class SlotAttention(BertPreTrainedModel):
                 start_positions=None, end_positions=None):
         sequence_output, pool_output = self.bert(input_ids,
                                                  attention_mask=attention_mask,
-                                                 token_type_ids=token_type_ids)
+                                                 token_type_ids=token_type_ids,
+                                                 return_dict=False)
 
         slot_hidden = self.bert.embeddings(slot_input_ids[0][0]).mean(-2)
 

--- a/sa_utils.py
+++ b/sa_utils.py
@@ -4,8 +4,7 @@ from io import open
 from tqdm import tqdm
 import os
 import pickle
-from transformers.tokenization_bert import BertTokenizer
-from transformers import BertModel, BertConfig
+from transformers import BertTokenizer, BertConfig
 from vn_model import ValueNormalize
 import torch
 from torch import nn

--- a/vn_run.py
+++ b/vn_run.py
@@ -272,7 +272,7 @@ def main():
     args.n_gpu = torch.cuda.device_count()
     set_seed(args)
 
-    logger.warning("Process device: %s, n_gpu: %s, 16-bits training: %s", args.device, args.n_gpu)
+    logger.warning("Process device: %s, n_gpu: %s, 16-bits training: %s", args.device, args.n_gpu, args.fp16)
     logger.info("Training/evaluation parameters %s", args)
 
     if args.fp16:


### PR DESCRIPTION
fix https://github.com/wyxlzsq/savn/issues/2 
https://github.com/huggingface/transformers/releases/tag/v4.0.0
In order to obtain the same behavior as version v3.x, you should specify the return_dict argument to False, either in the model configuration or during the forward pass.

In version v3.x:
```python
outputs = model(**inputs)
```
to obtain the same in version v4.x:
```python
outputs = model(**inputs, return_dict=False)
```